### PR TITLE
rename Test, add some comments, use no type member at all

### DIFF
--- a/benchmarks/src/main/scala/testz/benchmarks/Main.scala
+++ b/benchmarks/src/main/scala/testz/benchmarks/Main.scala
@@ -43,7 +43,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object Main {
   def testPureSuite = new PureSuite {
-    def test[T](test: Test[Function0, T]): T =
+    def test[T](test: Harness[Function0, T]): T =
       test.section("some tests")(
         test("this test fails")(() =>
           assertEqualNoShow(1, 2)
@@ -55,7 +55,7 @@ object Main {
   }
 
   def testTaskSuite = new TaskSuite {
-    def test[T](test: Test[Task, Task[T]]): Task[T] = {
+    def test[T](test: Harness[Task, Task[T]]): Task[T] = {
       def doMoreTests(ts: Task[T], i: Int): Task[T] = {
         if (i == 0) ts
         else doMoreTests(

--- a/core/src/main/scala/testz/Harness.scala
+++ b/core/src/main/scala/testz/Harness.scala
@@ -30,12 +30,24 @@
 
 package testz
 
+/** A test harness.
+  *
+  * Provides a way to create a test definition (of type `T`) from assertions
+  * and other nested tests. The execution of the tests takes place within some
+  * effect `F`, which provides the ability to test impure and/or asynchronous
+  * code as well as pure code.
+  */
 trait Harness[F[_], T] {
-  def apply(name: String)(assertions: F[List[TestError]]): T
-  def section(name: String)(test1: T, tests: T*): T
-}
 
-sealed trait TestError
-final case class ExceptionThrown(thrown: Throwable) extends TestError
-final case class Failure(failureAsString: String) extends TestError
-// TODO: use pretty-printer
+  /** Create a test named `name` which runs the given assertion.
+    *
+    * The test is considered successful if running the assertion produces an
+    * empty list of errors.
+    */
+  def apply(name: String)(assertion: F[List[TestError]]): T
+
+  /** Create a named test section out of the provided tests.
+    */
+  def section(name: String)(test1: T, tests: T*): T
+
+}

--- a/core/src/main/scala/testz/TestError.scala
+++ b/core/src/main/scala/testz/TestError.scala
@@ -1,0 +1,6 @@
+package testz
+
+sealed trait TestError
+final case class ExceptionThrown(thrown: Throwable) extends TestError
+final case class Failure(failureAsString: String) extends TestError
+// TODO: use pretty-printer

--- a/core/src/main/scala/testz/TestError.scala
+++ b/core/src/main/scala/testz/TestError.scala
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2018, Edmund Noble
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package testz
 
 sealed trait TestError

--- a/core/src/main/scala/testz/data.scala
+++ b/core/src/main/scala/testz/data.scala
@@ -30,7 +30,7 @@
 
 package testz
 
-trait Test[F[_], T] {
+trait Harness[F[_], T] {
   def apply(name: String)(assertions: F[List[TestError]]): T
   def section(name: String)(test1: T, tests: T*): T
 }

--- a/docs/src/main/tut/docs/02-A-First-Example.md
+++ b/docs/src/main/tut/docs/02-A-First-Example.md
@@ -12,12 +12,12 @@ most basic suite type provided. We'll be using `testz-core`,
 It's provided in `testz.stdlib.PureSuite`.
 
 ```tut:silent
-import testz.{PureSuite, Test}
+import testz.{PureSuite, Harness}
 import testz.stdlib.assertEqual
 import scala.concurrent.ExecutionContext.global
 
 final class MathTests extends PureSuite {
-  def test[T](test: Test[Function0, T]): T = {
+  def test[T](test: Harness[Function0, T]): T = {
     test.section("math must")(
       test("say 1 + 1 == 2") { () =>
         assertEqual(1 + 1, 2)
@@ -38,14 +38,14 @@ new MathTests().run(global)
 I went through a lot there; let's dissect that.
 
 ```tut:silent
-import testz.{PureSuite, Test}
+import testz.{PureSuite, Harness}
 import testz.stdlib.assertEqual
 import scala.concurrent.ExecutionContext.global
 ```
 
-Here I import `Test[F[_], T]`, the type of test harnesses in testz.
+Here I import `Harness[F[_], T]`, the type of test harnesses in testz.
 Conventionally, test suites are written to extend a test suite class
-with an abstract method that takes a `Test` as a parameter.
+with an abstract method that takes a `Harness` as a parameter.
 
 I also import `assertEqual` from `testz.stdlib`; assertions are just
 lists of errors in testz. `assertEqual` returns an empty list of
@@ -53,7 +53,7 @@ errors if the two arguments are equal; otherwise it returns a single
 error.
 
 `PureSuite` is the test suite class I'm using. The type of test
-harness it uses is a `Test[Function0, T]` for all `T`, and it returns a
+harness it uses is a `Harness[Function0, T]` for all `T`, and it returns a
 `T` at the end. The idea behind this is for the test code to be unaware
 of what the type `T` will be. So the only way it can return a `T` is to
 use the test harness.
@@ -76,7 +76,7 @@ while tests run. Instead, use a class to keep your working set small
 during the run.
 
 ```scala
-def test[T](test: Test[Function0, T]): T = {
+def test[T](test: Harness[Function0, T]): T = {
 ```
 
 Here we define a method from `PureSuite` which we will use to define our tests.

--- a/docs/src/main/tut/docs/03-stdlib.md
+++ b/docs/src/main/tut/docs/03-stdlib.md
@@ -15,5 +15,5 @@ The only method to override on `PureSuite` is `test`, the signature
 of which is:
 
 ```scala
-def test[T](test: Test[Function0, T]): T
+def test[T](test: Harness[Function0, T]): T
 ```

--- a/runner/src/main/scala/testz/runner/Suite.scala
+++ b/runner/src/main/scala/testz/runner/Suite.scala
@@ -33,6 +33,15 @@ package runner
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/** A test suite, which executes tests and asychronously produces a list of
+  * messages.
+  *
+  * Test writers should use a subclass of `Suite`, such as:
+  *
+  * - `PureSuite`, which tests synchronous, pure values using [[Function0]]
+  * - `ImpureSuite`, which tests potentially asynchronous values using [[Future]]
+  * - `TaskSuite`, which tests arbitrary effects using scalaz [[Task]]
+  */
 trait Suite {
   def run(implicit ec: ExecutionContext): Future[List[String]]
 }

--- a/scalaz/src/main/scala/testz/z.scala
+++ b/scalaz/src/main/scala/testz/z.scala
@@ -74,7 +74,7 @@ object z {
   implicit val equalTestError: Equal[TestError] = Equal.equalA
 
   abstract class TaskSuite extends Suite {
-    def test[T](test: Test[Task, Task[T]]): Task[T]
+    def test[T](test: Harness[Task, Task[T]]): Task[T]
     def run(implicit ec: ExecutionContext): Future[List[String]] = {
       type TestEff[A] = ReaderT[Task, List[String], A]
       val buf = Task.delay(new AtomicReference[List[String]](Nil))
@@ -83,8 +83,8 @@ object z {
         val _ = buf.updateAndGet(xs => str :: xs)
       }
 
-      def test(buf: AtomicReference[List[String]]): Test[Task, Task[TestEff[Unit]]] =
-        new Test[Task, Task[TestEff[Unit]]] {
+      def test(buf: AtomicReference[List[String]]): Harness[Task, Task[TestEff[Unit]]] =
+        new Harness[Task, Task[TestEff[Unit]]] {
           def apply
             (name: String)
             (assertion: Task[List[TestError]]

--- a/specs2/src/main/scala/testz/specs2.scala
+++ b/specs2/src/main/scala/testz/specs2.scala
@@ -36,10 +36,10 @@ import org.specs2.specification.core.Fragment
 object specs2 {
 
   abstract class TaskSuite() extends mutable.Specification {
-    def test[T](test: Test[Function0, Function0[T]]): Function0[T]
+    def test[T](test: Harness[Function0, Function0[T]]): Function0[T]
 
-    private def makeHarness: Test[() => ?, () => Fragment] =
-      new Test[() => ?, () => Fragment] {
+    private def makeHarness: Harness[() => ?, () => Fragment] =
+      new Harness[() => ?, () => Fragment] {
         def apply
           (name: String)
           (assertion: () => List[TestError])

--- a/tests/src/main/scala/testz/ExhaustiveSuite.scala
+++ b/tests/src/main/scala/testz/ExhaustiveSuite.scala
@@ -40,7 +40,7 @@ final class ExhaustiveSuite extends PureSuite {
       Unfold((1 to 5).toList.map(_ + n): _*)
   }
 
-  def test[T](test: Test[() => ?, T]): T =
+  def test[T](test: Harness[() => ?, T]): T =
     test.section("exhaustives")(
       test("exhaustiveS int range") { () =>
         exhaustiveS(1, 2, 3, 4, 5, 6)(i =>

--- a/tests/src/main/scala/testz/StdlibSuite.scala
+++ b/tests/src/main/scala/testz/StdlibSuite.scala
@@ -33,7 +33,7 @@ package testz
 import testz.stdlib._
 
 final class StdlibSuite extends PureSuite {
-  def test[T](test: Test[Function0, T]): T = {
+  def test[T](test: Harness[Function0, T]): T = {
     test.section("equality assertions")(
       test("assertEqual/assertEqual") { () =>
         assertEqual(assertEqual(1 + 1, 2), Nil)


### PR DESCRIPTION
Rename `Test` => `Harness`.

~~Similar to how `TestTree` is abstract in tasty, let the result of `Harness#apply` and `Harness#section` be abstract.~~