### PR TITLE
Remove code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,3 @@ The pure testing library by scalaz.
     utest, scalatest, and specs2; I believe none of these come close to delivering a library. One consequence is, I don't consider any of them to be functional either;
     frameworks are emphatically not functional programming from where I'm standing.
 
-
-## Contributing
-
-This project is released under the scalaz code of conduct.


### PR DESCRIPTION
As far as I can tell there's no mention of any code of conduct in scalaz/scalaz, so there's no reason to have it here.